### PR TITLE
Improve workflows.do AI type definitions

### DIFF
--- a/sdks/workflows.do/src/index.ts
+++ b/sdks/workflows.do/src/index.ts
@@ -32,6 +32,8 @@ import type {
   AIContext,
   AIEventHandler,
   AIInstance,
+  AIInstanceFromConfig,
+  RemoteAIInstance,
   DatabaseAccess,
   APIAccess,
 } from './types'
@@ -42,7 +44,7 @@ import { API } from './client.js'
  * @param config Object containing event handlers and function schemas
  * @returns AI instance with typed methods
  */
-export function AI<T extends AIConfig>(config: T): AIInstance {
+export function AI<T extends AIConfig>(config: T): AIInstanceFromConfig<T> {
   const instance: Record<string, AIFunction> = {}
 
   const workflowConfig: Record<string, any> = {}
@@ -150,7 +152,7 @@ export function AI<T extends AIConfig>(config: T): AIInstance {
     },
   })
 
-  return proxy as AIInstance
+  return proxy as AIInstanceFromConfig<T>
 }
 
 /**
@@ -343,7 +345,7 @@ export function every(cronExpression: string, handler: AIEventHandler, options?:
 /**
  * AI instance with typed methods
  */
-export const ai = new Proxy({} as AIInstance, {
+export const ai = new Proxy({} as RemoteAIInstance, {
   get: (target, prop: string) => {
     if (typeof prop === 'string' && !prop.startsWith('_')) {
       return async (input: any) => {
@@ -401,6 +403,8 @@ export type {
   AIContext,
   AIEventHandler,
   AIInstance,
+  AIInstanceFromConfig,
+  RemoteAIInstance,
   DatabaseAccess,
   APIAccess,
 }

--- a/sdks/workflows.do/src/types.ts
+++ b/sdks/workflows.do/src/types.ts
@@ -80,6 +80,33 @@ export interface AIInstance {
 }
 
 /**
+ * AI instance type generated from a specific configuration.
+ *
+ * Each entry in the configuration becomes a callable function where:
+ *  - event handlers are exposed as functions receiving the event payload and
+ *    returning the handler result.
+ *  - function schemas are exposed as functions receiving the schema input and
+ *    returning the expected output defined by the schema.
+ */
+export type AIInstanceFromConfig<T extends AIConfig> = {
+  [K in keyof T]: T[K] extends AIEventHandler<infer E, infer R>
+    ? (event: E) => Promise<R>
+    : T[K] extends AIFunctionSchema<infer O>
+      ? (input: Record<string, any>) => Promise<O>
+      : never
+}
+
+/**
+ * Remote workflow executor used by the {@link ai} proxy.
+ *
+ * Keys represent workflow names and values are functions executing the remote
+ * workflow with the provided input.
+ */
+export interface RemoteAIInstance {
+  [workflowName: string]: AIFunction
+}
+
+/**
  * Workflow step configuration
  */
 export interface WorkflowStep {


### PR DESCRIPTION
## Summary
- expand `AIInstanceFromConfig` with generics for returned instance
- add `RemoteAIInstance` for the `ai` proxy
- return `AIInstanceFromConfig` from `AI`
- export new types

## Testing
- `pnpm --filter ./sdks/workflows.do build`
- `pnpm --filter ./sdks/workflows.do test` *(fails: ReferenceError: Cannot access 'apis' before initialization)*