### PR TITLE
Update Business-as-Code doc

### DIFF
--- a/platform/content/business-as-code.mdx
+++ b/platform/content/business-as-code.mdx
@@ -38,134 +38,85 @@ const turboLoans = Business({
     keyMetrics: ['Application conversion rate', 'Loan approval time', 'Customer satisfaction index'],
     unfairAdvantage: 'Proprietary AI algorithm optimized for speed and accuracy in credit evaluation',
   },
-  goals: [
-    { objective: 'Grow market share' },
-    { objective: 'Enhance profitability' },
-    { objective: 'Improve customer satisfaction' },
-  ],
-  ceo: Human({ email: 'alex@turboloans.co' }),
-  cmo: Agent({})
-  cto: Human({
-    email: 'tom@turboloans.co',
-    objective: 'Build the industry-leading digital lending platform',
-    keyResults: [],
-  }),
-})
-
-turboLoans.on('CreditApp.Submitted', async (creditApp, { ai, api, db }) => {
-
-})
-
-turboLoans.every('hour', async ({ kpis }, { ai, api, db }) => {
-
-})
-
-```
-
-```ts
-/* ----------
- * 🏢 1. Company manifest
- * ---------- */
-import { Business, on, every } from 'workflows.do'
-import { Agent } from 'agents.do'
-import { Human } from 'humans.do'
-
-export const turboLoans = Business({
-  name: 'TurboLoans',
-  url: 'https://turboloans.co',
-  vision: 'Fast, affordable, and transparent consumer loans',
-
-  /* 🌍 High-level objectives */
-  goals: [
-    { objective: 'Grow market share', keyResults: ['▲ qualified leads / week', '▲ funded loans / month'] },
-    { objective: 'Enhance profitability', keyResults: ['▼ CAC', '▲ approval rate', '▲ net revenue / loan'] },
-    { objective: 'Delight customers', keyResults: ['NPS ≥ 75', 'CSAT ≥ 95%'] },
-  ],
-
-  /* 👥 Core roles (mix of humans & agents) */
+  goals: {
+    'Grow market share': ['▲ qualified leads / week', '▲ funded loans / month'],
+    'Enhance profitability': ['▼ CAC', '▲ approval rate', '▲ net revenue / loan'],
+    'Delight customers': ['NPS ≥ 75', 'CSAT ≥ 95%'],
+  },
   ceo: Human({ name: 'Alex', email: 'alex@turboloans.co' }),
+  cmo: Agent({
+    name: 'Clara',
+    objective: 'Acquire quality traffic at ≤ $35 CAC',
+    keyResults: ['▼ CAC', '▲ conversion rate'],
+  }),
   cto: Human({
     name: 'Tom',
     email: 'tom@turboloans.co',
-    objective: 'Own the industry-leading digital lending platform',
+    objective: 'Build the industry-leading digital lending platform',
     keyResults: ['▼ avg. decision latency', '▲ automated verifications'],
   }),
-
-  cmo: Agent({ name: 'Clara', objective: 'Acquire quality traffic at ≤ $35 CAC', keyResults: ['▼ CAC', '▲ conversion rate'] }),
-
-  /* 🏢 Departments (optional, composable) */
-  departments: {
-    underwriting: Agent({ name: 'Underwriter' }),
-    funding: Human({ name: 'Fran Funding', email: 'fund@turboloans.co' }),
-  },
 })
 
-/* ----------
- * 🛠️ 2. Event-driven workflow fragments
- * ---------- */
+turboLoans.on('CreditApp.Submitted', async (app, { ai, db, taskQueue }) => {
+  const score = await ai.call('riskScore', {
+    creditReport: app.creditReport,
+    income: app.income,
+  })
+  const terms = await ai.call('priceLoan', {
+    score,
+    amount: app.amount,
+    term: app.term,
+  })
 
-/* A. When a credit application arrives */
-on('CreditApp.Submitted', async (app, { ai, db, taskQueue }) => {
-  const riskScore = await ai.call('riskScore', { creditReport: app.creditReport, income: app.income })
-  const offerTerms = await ai.call('priceLoan', { score: riskScore, amount: app.amount, term: app.term })
+  await db.loans.update(app.id, { score, terms })
 
-  /* Persist & branch */
-  await db.loans.update(app.id, { riskScore, offerTerms })
-
-  if (riskScore >= 700) {
-    taskQueue.enqueue('SendOffer', { applicantId: app.id, offerTerms })
+  if (score >= 700) {
+    taskQueue.enqueue('SendOffer', { applicantId: app.id, terms })
   } else {
-    taskQueue.enqueue('RequestDocs', { applicantId: app.id, docs: ['paystubs', 'bankStatements'] })
+    taskQueue.enqueue('RequestDocs', {
+      applicantId: app.id,
+      docs: ['paystubs', 'bankStatements'],
+    })
   }
 })
 
-/* B. When required documents are uploaded */
-on('Docs.Uploaded', async (evt, { ai, db, taskQueue }) => {
-  const verified = await ai.call('verifyDocs', { docs: evt.docs, applicantId: evt.applicantId })
+turboLoans.on('Docs.Uploaded', async (evt, { ai, db, taskQueue }) => {
+  const verified = await ai.call('verifyDocs', {
+    docs: evt.docs,
+    applicantId: evt.applicantId,
+  })
   await db.docs.update(evt.applicantId, { verified })
 
   verified === true
     ? taskQueue.enqueue('PrepareFunding', { applicantId: evt.applicantId })
-    : taskQueue.enqueue('RequestMoreInfo', { applicantId: evt.applicantId, missing: verified.missing })
+    : taskQueue.enqueue('RequestMoreInfo', {
+        applicantId: evt.applicantId,
+        missing: verified.missing,
+      })
 })
 
-/* ----------
- * ⏰ 3. Time-driven continuous improvement loops
- * ---------- */
-
-/* Hourly KPI pulse */
-every('hour', async ({ ai, db, task }) => {
-  const funnel = await db.loans.funnelMetrics() // e.g. { submitted: 120, approved: 45, funded: 30 }
-  const plan = await ai.plan('improveFunnel', funnel) // returns an array of suggested actions
-
+turboLoans.every('hour', async ({ ai, db, task }) => {
+  const funnel = await db.loans.funnelMetrics()
+  const plan = await ai.plan('improveFunnel', funnel)
   plan.forEach((action) => task.do(action.type, action.payload))
 })
 
-/* Daily strategic planning (7 AM CT) */
-every('day at 07:00', async ({ ai, db }) => {
+turboLoans.every('day at 07:00', async ({ ai, db }) => {
   const yesterday = await db.kpis.snapshot('yesterday')
-  const todayPlan = await ai.plan('dailyObjectives', { kpis: yesterday, okrs: turboLoans.goals })
-
-  await db.tasks.bulkInsert(todayPlan.tasks) // populate today’s work queue
+  const todayPlan = await ai.plan('dailyObjectives', {
+    kpis: yesterday,
+    okrs: turboLoans.goals,
+  })
+  await db.tasks.bulkInsert(todayPlan.tasks)
 })
 
-/* Weekly OKR review (Monday, 8 AM CT) */
-every('week on Mon at 08:00', async ({ ai, db, task }) => {
+turboLoans.every('week on Mon at 08:00', async ({ ai, db, task }) => {
   const progress = await db.kpis.progressAgainstOKRs(turboLoans.goals)
   const insights = await ai.call('generateOKRReport', { progress })
-
   task.do('SendReport', { to: turboLoans.ceo.email, report: insights })
-  task.do('ShareUpdate', { channel: '#team-turbo', summary: insights.summary })
+  task.do('ShareUpdate', {
+    channel: '#team-turbo',
+    summary: insights.summary,
+  })
 })
-
-/* ----------
- * 📮 4. Minimal task handlers
- * ---------- */
-on('SendOffer', async (task, { email }) => email.to(task.applicantId, 'Your Loan Offer', task.offerTerms))
-on('RequestDocs', async (task, { email }) => email.to(task.applicantId, 'Additional Docs', task.docsNeeded))
-on('PrepareFunding', async (task, { funding }) => funding.initiate(task.applicantId))
-on('SendReport', async (task, { email }) => email.to(task.to, 'Weekly OKR Report', task.report))
-on('ShareUpdate', async (task, { chat }) => chat.post(task.channel, task.summary))
 ```
-
-≤ $35

--- a/platform/content/manifesto/business-as-code.mdx
+++ b/platform/content/manifesto/business-as-code.mdx
@@ -38,134 +38,85 @@ const turboLoans = Business({
     keyMetrics: ['Application conversion rate', 'Loan approval time', 'Customer satisfaction index'],
     unfairAdvantage: 'Proprietary AI algorithm optimized for speed and accuracy in credit evaluation',
   },
-  goals: [
-    { objective: 'Grow market share' },
-    { objective: 'Enhance profitability' },
-    { objective: 'Improve customer satisfaction' },
-  ],
-  ceo: Human({ email: 'alex@turboloans.co' }),
-  cmo: Agent({})
-  cto: Human({
-    email: 'tom@turboloans.co',
-    objective: 'Build the industry-leading digital lending platform',
-    keyResults: [],
-  }),
-})
-
-turboLoans.on('CreditApp.Submitted', async (creditApp, { ai, api, db }) => {
-
-})
-
-turboLoans.every('hour', async ({ kpis }, { ai, api, db }) => {
-
-})
-
-```
-
-```ts
-/* ----------
- * 🏢 1. Company manifest
- * ---------- */
-import { Business, on, every } from 'workflows.do'
-import { Agent } from 'agents.do'
-import { Human } from 'humans.do'
-
-export const turboLoans = Business({
-  name: 'TurboLoans',
-  url: 'https://turboloans.co',
-  vision: 'Fast, affordable, and transparent consumer loans',
-
-  /* 🌍 High-level objectives */
-  goals: [
-    { objective: 'Grow market share', keyResults: ['▲ qualified leads / week', '▲ funded loans / month'] },
-    { objective: 'Enhance profitability', keyResults: ['▼ CAC', '▲ approval rate', '▲ net revenue / loan'] },
-    { objective: 'Delight customers', keyResults: ['NPS ≥ 75', 'CSAT ≥ 95%'] },
-  ],
-
-  /* 👥 Core roles (mix of humans & agents) */
+  goals: {
+    'Grow market share': ['▲ qualified leads / week', '▲ funded loans / month'],
+    'Enhance profitability': ['▼ CAC', '▲ approval rate', '▲ net revenue / loan'],
+    'Delight customers': ['NPS ≥ 75', 'CSAT ≥ 95%'],
+  },
   ceo: Human({ name: 'Alex', email: 'alex@turboloans.co' }),
+  cmo: Agent({
+    name: 'Clara',
+    objective: 'Acquire quality traffic at ≤ $35 CAC',
+    keyResults: ['▼ CAC', '▲ conversion rate'],
+  }),
   cto: Human({
     name: 'Tom',
     email: 'tom@turboloans.co',
-    objective: 'Own the industry-leading digital lending platform',
+    objective: 'Build the industry-leading digital lending platform',
     keyResults: ['▼ avg. decision latency', '▲ automated verifications'],
   }),
-
-  cmo: Agent({ name: 'Clara', objective: 'Acquire quality traffic at ≤ $35 CAC', keyResults: ['▼ CAC', '▲ conversion rate'] }),
-
-  /* 🏢 Departments (optional, composable) */
-  departments: {
-    underwriting: Agent({ name: 'Underwriter' }),
-    funding: Human({ name: 'Fran Funding', email: 'fund@turboloans.co' }),
-  },
 })
 
-/* ----------
- * 🛠️ 2. Event-driven workflow fragments
- * ---------- */
+turboLoans.on('CreditApp.Submitted', async (app, { ai, db, taskQueue }) => {
+  const score = await ai.call('riskScore', {
+    creditReport: app.creditReport,
+    income: app.income,
+  })
+  const terms = await ai.call('priceLoan', {
+    score,
+    amount: app.amount,
+    term: app.term,
+  })
 
-/* A. When a credit application arrives */
-on('CreditApp.Submitted', async (app, { ai, db, taskQueue }) => {
-  const riskScore = await ai.call('riskScore', { creditReport: app.creditReport, income: app.income })
-  const offerTerms = await ai.call('priceLoan', { score: riskScore, amount: app.amount, term: app.term })
+  await db.loans.update(app.id, { score, terms })
 
-  /* Persist & branch */
-  await db.loans.update(app.id, { riskScore, offerTerms })
-
-  if (riskScore >= 700) {
-    taskQueue.enqueue('SendOffer', { applicantId: app.id, offerTerms })
+  if (score >= 700) {
+    taskQueue.enqueue('SendOffer', { applicantId: app.id, terms })
   } else {
-    taskQueue.enqueue('RequestDocs', { applicantId: app.id, docs: ['paystubs', 'bankStatements'] })
+    taskQueue.enqueue('RequestDocs', {
+      applicantId: app.id,
+      docs: ['paystubs', 'bankStatements'],
+    })
   }
 })
 
-/* B. When required documents are uploaded */
-on('Docs.Uploaded', async (evt, { ai, db, taskQueue }) => {
-  const verified = await ai.call('verifyDocs', { docs: evt.docs, applicantId: evt.applicantId })
+turboLoans.on('Docs.Uploaded', async (evt, { ai, db, taskQueue }) => {
+  const verified = await ai.call('verifyDocs', {
+    docs: evt.docs,
+    applicantId: evt.applicantId,
+  })
   await db.docs.update(evt.applicantId, { verified })
 
   verified === true
     ? taskQueue.enqueue('PrepareFunding', { applicantId: evt.applicantId })
-    : taskQueue.enqueue('RequestMoreInfo', { applicantId: evt.applicantId, missing: verified.missing })
+    : taskQueue.enqueue('RequestMoreInfo', {
+        applicantId: evt.applicantId,
+        missing: verified.missing,
+      })
 })
 
-/* ----------
- * ⏰ 3. Time-driven continuous improvement loops
- * ---------- */
-
-/* Hourly KPI pulse */
-every('hour', async ({ ai, db, task }) => {
-  const funnel = await db.loans.funnelMetrics() // e.g. { submitted: 120, approved: 45, funded: 30 }
-  const plan = await ai.plan('improveFunnel', funnel) // returns an array of suggested actions
-
+turboLoans.every('hour', async ({ ai, db, task }) => {
+  const funnel = await db.loans.funnelMetrics()
+  const plan = await ai.plan('improveFunnel', funnel)
   plan.forEach((action) => task.do(action.type, action.payload))
 })
 
-/* Daily strategic planning (7 AM CT) */
-every('day at 07:00', async ({ ai, db }) => {
+turboLoans.every('day at 07:00', async ({ ai, db }) => {
   const yesterday = await db.kpis.snapshot('yesterday')
-  const todayPlan = await ai.plan('dailyObjectives', { kpis: yesterday, okrs: turboLoans.goals })
-
-  await db.tasks.bulkInsert(todayPlan.tasks) // populate today’s work queue
+  const todayPlan = await ai.plan('dailyObjectives', {
+    kpis: yesterday,
+    okrs: turboLoans.goals,
+  })
+  await db.tasks.bulkInsert(todayPlan.tasks)
 })
 
-/* Weekly OKR review (Monday, 8 AM CT) */
-every('week on Mon at 08:00', async ({ ai, db, task }) => {
+turboLoans.every('week on Mon at 08:00', async ({ ai, db, task }) => {
   const progress = await db.kpis.progressAgainstOKRs(turboLoans.goals)
   const insights = await ai.call('generateOKRReport', { progress })
-
   task.do('SendReport', { to: turboLoans.ceo.email, report: insights })
-  task.do('ShareUpdate', { channel: '#team-turbo', summary: insights.summary })
+  task.do('ShareUpdate', {
+    channel: '#team-turbo',
+    summary: insights.summary,
+  })
 })
-
-/* ----------
- * 📮 4. Minimal task handlers
- * ---------- */
-on('SendOffer', async (task, { email }) => email.to(task.applicantId, 'Your Loan Offer', task.offerTerms))
-on('RequestDocs', async (task, { email }) => email.to(task.applicantId, 'Additional Docs', task.docsNeeded))
-on('PrepareFunding', async (task, { funding }) => funding.initiate(task.applicantId))
-on('SendReport', async (task, { email }) => email.to(task.to, 'Weekly OKR Report', task.report))
-on('ShareUpdate', async (task, { chat }) => chat.post(task.channel, task.summary))
 ```
-
-≤ $35


### PR DESCRIPTION
## Summary
- refactor goals to use objective/key result pairs
- flesh out CMO agent and CTO key results
- expand example workflows and remove outdated snippet

## Testing
- `pnpm lint`
- `pnpm check-types`
- `pnpm test` *(fails: missing secret key)*
